### PR TITLE
frontend: Fix some code inconsistencies

### DIFF
--- a/python/frontend/cirrus/cirrus/cf.py
+++ b/python/frontend/cirrus/cirrus/cf.py
@@ -16,8 +16,8 @@ class CollaborativeFilteringTask(BaseTask):
             grad_t = 1
         else:
             grad_t = 0
-        config = "input_path: /home/ec2-user/cirrus/examples/ml/tests/test_mf/nf_parsed \n" + \
-                 "input_type: csv \n" + \
+        config = "load_input_path: /home/ec2-user/cirrus/examples/ml/tests/test_mf/nf_parsed \n" + \
+                 "load_input_type: csv \n" + \
                  "minibatch_size: %d \n" % self.minibatch_size + \
                  "s3_size: 10000 \n" + \
                  "model_type: CollaborativeFiltering \n" + \
@@ -38,7 +38,7 @@ class CollaborativeFilteringTask(BaseTask):
 def CollaborativeFiltering(
             n_workers,
             n_ps,
-            lambda_size,
+            worker_size,
             dataset,
         learning_rate, epsilon,
         progress_callback,
@@ -62,7 +62,7 @@ def CollaborativeFiltering(
     return CollaborativeFilteringTask(
             n_workers=n_workers,
             n_ps=n_ps,
-            lambda_size=lambda_size,
+            worker_size=worker_size,
             dataset=dataset,
             learning_rate=learning_rate,
             epsilon=epsilon,

--- a/python/frontend/cirrus/cirrus/core.py
+++ b/python/frontend/cirrus/cirrus/core.py
@@ -27,7 +27,7 @@ class BaseTask(object):
 
     def __init__(self,
             n_workers,
-            lambda_size,
+            worker_size,
             n_ps,
             dataset,
             learning_rate,
@@ -52,6 +52,7 @@ class BaseTask(object):
         self.thread = threading.Thread(target=self.run)
         self.n_workers = n_workers
         self.n_ps = n_ps
+        self.worker_size = worker_size
         self.dataset=dataset
         self.learning_rate = learning_rate
         self.epsilon = epsilon
@@ -85,7 +86,7 @@ class BaseTask(object):
                     self.n_ps,
                     0,
                     self.n_workers,
-                    self.lambda_size)
+                    self.worker_size)
 
         self.start_time = time.time()
 
@@ -257,7 +258,7 @@ class BaseTask(object):
             for i in range(shortage):
                 try:
                     response = lambda_client.invoke(
-                        FunctionName=lambda_name,
+                        FunctionName="%s_%d" % (lambda_name, self.worker_size),
                         InvocationType='Event',
                         LogType='Tail',
                         Payload=payload)

--- a/python/frontend/cirrus/cirrus/lr.py
+++ b/python/frontend/cirrus/cirrus/lr.py
@@ -18,8 +18,8 @@ class LogisticRegressionTask(BaseTask):
         else:
             grad_t = 0
 
-        config = "input_path: /mnt/efs/criteo_kaggle/train.csv \n" + \
-                 "input_type: csv\n" + \
+        config = "load_input_path: /mnt/efs/criteo_kaggle/train.csv \n" + \
+                 "load_input_type: csv\n" + \
                  "num_classes: 2 \n" + \
                  "num_features: 13 \n" + \
                  "limit_cols: 14 \n" + \
@@ -43,7 +43,7 @@ class LogisticRegressionTask(BaseTask):
 def LogisticRegression(
             n_workers,
             n_ps,
-            lambda_size,
+            worker_size,
             dataset,
             learning_rate, 
             progress_callback,
@@ -68,7 +68,7 @@ def LogisticRegression(
             ):
     return LogisticRegressionTask(
             n_workers=n_workers,
-            lambda_size=lambda_size,
+            worker_size=worker_size,
             n_ps=n_ps,
             dataset=dataset,
             learning_rate=learning_rate,

--- a/python/frontend/cirrus/cirrus/utils.py
+++ b/python/frontend/cirrus/cirrus/utils.py
@@ -263,8 +263,8 @@ def public_dns_to_private_ip(public_dns):
     return instances[0]['PrivateIpAddress']
 
 
-def lambda_exists(existing, name):
-    """ lambda_exists(existing, name, size, zip_location)
+def lambda_exists(existing, name, size, zip_location):
+    """
     TODO: Check to see if uploaded SHA256 matches current bundle's SHA256
     Code below doesn't work, not sure if I need to hash zip or
     underlying code.

--- a/python/frontend/cirrus/examples/HyperParamDashDemo.ipynb
+++ b/python/frontend/cirrus/examples/HyperParamDashDemo.ipynb
@@ -61,7 +61,7 @@
     "                       param_base=basic_params,\n",
     "                       hyper_vars=[\"learning_rate\", \"worker_size\"],\n",
     "                       hyper_params=[[0.1, 0.2], [128, 246, 512]],\n",
-    "                       machines=[(public_ps_ip, private_ps_ip)])\n",
+    "                       machines=[public_ps_ip])\n",
     "gs.set_threads(2)\n",
     "gs.run(UI=True)"
    ]

--- a/python/frontend/cirrus/examples/UIExample.py
+++ b/python/frontend/cirrus/examples/UIExample.py
@@ -3,8 +3,6 @@ from context import cirrus
 urls = [
         "ec2-18-237-213-139.us-west-2.compute.amazonaws.com"
         ]
-ips = [
-       "172.31.14.190"]
 data_bucket = 'cirrus-criteo-kaggle-19b-random'
 model = 'model_v1'
 
@@ -42,7 +40,7 @@ if __name__ == "__main__":
     interval = 0.001
 
         
-    machines = zip(urls, ips)
+    machines = urls
 
 
     learning_rates = [0.5/i for i in range(1, 20)]

--- a/python/frontend/cirrus/requirements.txt
+++ b/python/frontend/cirrus/requirements.txt
@@ -13,6 +13,7 @@ Markdown==2.6.11
 mmh3==2.5.1
 paramiko==2.4.2
 plotly==2.7.0
+psutil==5.6.7
 pylint==1.9.3
 redis==2.10.6
 scikit-learn==0.19.2


### PR DESCRIPTION
- Add missing requirement to `requirements.txt`
- Adjust some code inconsistencies
  - e.g., `lambda_size` is used as a keyword argument when no such keyword argument exists. Should be `worker_size` instead.
  - e.g., in `examples/`, giving `GridSearch()` a keyword argument of `machines=[<tuple>]` gives an error `Invalid type for parameter Filters[0].Values[0], value: ('ec2-18-237-213-139.us-west-2.compute.amazonaws.com', '172.31.14.190'), type: <type 'tuple'>, valid types: <type 'basestring'>`.